### PR TITLE
Fix commas in code blocks of markdown being rendered as `undefined`

### DIFF
--- a/packages/gatsby-remark-prismjs/src/escape-html.js
+++ b/packages/gatsby-remark-prismjs/src/escape-html.js
@@ -16,7 +16,7 @@ module.exports = (code, additionalHtmlEscapes = {}) => {
 
   const chars = Object.keys(htmlEscapes)
 
-  const charsRe = new RegExp(`[${chars.join()}]`, `g`)
+  const charsRe = new RegExp(`[${chars.join('')}]`, `g`)
 
   const rehasUnescapedChars = new RegExp(charsRe.source)
 


### PR DESCRIPTION
## Description

If a comma appeared in a code block in markdown with the Remark/PrismJS plugin, it was being rendered as the string `undefined`. This PR fixes that so commas are now rendered as commas.

### Documentation

I'll need help with updating the documentation.  This bug affects Gatsby's website and it will have to be rebuilt with this fix.

## Related Issues

Fixes #20270